### PR TITLE
Fixed conflict with GLOBAL variables

### DIFF
--- a/lib/roles.js
+++ b/lib/roles.js
@@ -277,6 +277,10 @@ function addProfile(name, roles) {
 function exportRoles() {
 	var a = {}, p = {};
 
+	// These variables should be local, only used in this method, for the loops below.
+	// Without this line we accidently override anyone using a variable named `app` in NodeJS's GLOBAL namespace
+	// I can only assume the same would be true of the variable `prof`, so I added that here for completeness sake
+	var app, prof;
 	for (app in applications) {
 		if (applications.hasOwnProperty(app)) {
 			a[app] = [];
@@ -303,7 +307,11 @@ function exportRoles() {
 function importRoles(data) {
 	applications = {};
 	profiles = {};
-
+	
+	// These variables should be local, only used in this method, for the loops below.
+	// Without this line we accidently override anyone using a variable named `app` in NodeJS's GLOBAL namespace
+	// I can only assume the same would be true of the variable `prof`, so I added that here for completeness sake
+	var app, prof;
 	for (app in data.applications) {
 		if (data.applications.hasOwnProperty(app)) {
 			applications[app] = new Application(app);


### PR DESCRIPTION
While using Node-Roles I was also using the GLOBAL variable app, which Node-Roles accidentally overrides inside it's import method by not defining `var app`. I've fixed it in 2 places for both the variable app and prof, assuming the same would hold true for that variable as well. I have tested this change within my app and the conflict is resolved and the roles plugin still functions.
